### PR TITLE
bug: update crane export

### DIFF
--- a/manifests/clustertasks/crane-export.yaml
+++ b/manifests/clustertasks/crane-export.yaml
@@ -25,18 +25,10 @@ spec:
     - name: crane-export
       image: quay.io/konveyor/crane-runner:latest
       script: |
-        # Workspaces referencing secrets are read only, so we can't run
-        # anything like kubectl config use-context as that would fail
-        # the task. Instead we just create a whole new config to make
-        # sure we are using the correct context
-        # TODO(djzager): remove when `crane export` can handle context + namespace
-        kubectl --context $(params.src-context) config view --flatten --minify > kubeconfig
-        export KUBECONFIG=$(pwd)/kubeconfig
-
         /crane export \
           --context=$(params.src-context) \
           --namespace=$(params.src-namespace) \
-          --export-dir=$(workspaces.export.path) \
+          --export-dir=$(workspaces.export.path)
 
         # Do this so we have some breadcrumbs in case our demo blows up
         find $(workspaces.export.path)


### PR DESCRIPTION
Now that crane cli respects context, we don't need to mess with the
Kubeconfig.