### PR TITLE
bug: transfer-pvc clustertask's bad default value

### DIFF
--- a/config/clustertasks/crane-transform.yaml
+++ b/config/clustertasks/crane-transform.yaml
@@ -8,14 +8,16 @@ metadata:
       remove cluster specific metadata and status information. If optional-flags
       are defined, they will be passed to all enabled plugins.
 spec:
-  params:
-    - name: optional-flags
-      type: string
-      description: |
-        Comma separated list of `flag-name=value` pairs. These flags with values
-        will be passed into all plugins that are executed in the transform
-        operation.
-      default: "[]"
+  # params:
+  #   - name: optional-flags
+  #     type: string
+  #     description: |
+  #       Comma separated list of `flag-name=value` pairs. These flags with values
+  #       will be passed into all plugins that are executed in the transform
+  #       operation.
+  #     default: ""
+  # TODO(djzager): put this back
+  # --optional-flags="$(params.optional-flags)" \
   steps:
     - name: crane-transform
       image: quay.io/konveyor/crane-runner:latest
@@ -23,7 +25,6 @@ spec:
         crane transform \
           --ignored-patches-dir="$(workspaces.ignored-patches.path)" \
           --flags-file="$(workspaces.craneconfig.path)" \
-          --optional-flags="$(params.optional-flags)" \
           --export-dir="$(workspaces.export.path)" \
           --transform-dir=$(workspaces.transform.path)
 


### PR DESCRIPTION
The default value for transfer-pvc's `optional-flags` argument is not
correct. After playing with it offline, it does not appear there is a
string that can be passed to `optional-flags` that will be accepted.

Examples include `--optional-flags=""` `--optional-flags=''` and
`--optional-flags=[]`. We clearly need to move to another method for
building this command but for now we will just drop it.

Fixes #41 