### PR TITLE
feat(skopeo-sync-gen): Introduce new clustertask

### DIFF
--- a/config/clustertasks/crane-skopeo-sync-gen.yaml
+++ b/config/clustertasks/crane-skopeo-sync-gen.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  name: crane-skopeo-sync-gen
+  annotations:
+    description: |
+      Evaluate the resources from a `crane-export` and generate a source yaml
+      to be used with `skopeo sync --src yaml`.
+
+      The `oc-registry-info` ClusterTask can be used to retrieve the internal
+      and public registry URLs.
+
+      In the `skopeo` Workspace, the result will always be stored in
+      "source.yaml".
+spec:
+  params:
+    - name: internal-registry-url
+      type: string
+      description: |
+        This is the internal registry url (ie. image-registry.openshift-image-registry.svc:5000).
+    - name: public-registry-url
+      type: string
+      description: |
+        This is the public registry url.
+  steps:
+    - name: crane-skopeo-sync-gen
+      image: quay.io/konveyor/crane-runner:latest
+      script: |
+        set -e
+        set -o pipefail
+        set -x
+
+        crane skopeo-sync-gen \
+          --export-dir="$(workspaces.export.path)" \
+          --internal-registry-url="$(params.internal-registry-url)" \
+          --registry-url="$(params.public-registry-url)" | tee "$(workspaces.skopeo.path)/source.yaml"
+  workspaces:
+    - name: export
+      description: |
+        This is the folder where the results of crane export were stored.
+      mountPath: /var/crane/export
+    - name: skopeo
+      description: |
+        This is the folder where we will store the results of crane skopeo-sync-gen.
+      mountPath: /var/crane/skopeo

--- a/config/clustertasks/kustomization.yaml
+++ b/config/clustertasks/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - crane-kubeconfig-generator.yaml
   - crane-export.yaml
   - crane-transform.yaml
+  - crane-skopeo-sync-gen.yaml
   - crane-apply.yaml
   - crane-transfer-pvc.yaml
   - crane-kubectl-scale-down.yaml

--- a/config/clustertasks/oc-registry-info.yaml
+++ b/config/clustertasks/oc-registry-info.yaml
@@ -22,11 +22,18 @@ spec:
     - name: oc-registry-info
       image: quay.io/konveyor/crane-runner:latest
       script: |
-        oc --context="$(params.context)" registry info --internal | tee $(results.internal.path)
-        ( oc --context="$(params.context)" registry info --public || \
+        set -e
+        set -o pipefail
+        set -x
+
+        internal=$(oc --context="$(params.context)" registry info --internal)
+        public=$(oc --context="$(params.context)" registry info --public || \
           oc --context="$(params.context)" get route default-route -n openshift-image-registry --template='{{ .spec.host }}' || \
           oc --context="$(params.context)" get route docker-registry -n default --template='{{ .spec.host }}' \
-        ) | tee $(results.public.path)
+        )
+
+        echo -n "${internal}" | tee $(results.internal.path)
+        echo -n "${public}" | tee $(results.public.path)
       env:
         - name: KUBECONFIG
           value: $(workspaces.kubeconfig.path)/kubeconfig


### PR DESCRIPTION
Introduces a new ClusterTask responsible for running new `skopeo-sync-gen` subcommand of crane.
Also addresses issues with how `oc-registry-info` ClusterTask was emitting results (ie. remove newlines).

Fixes #55 