### PR TITLE
Add `verify` param to crane-transfer-pvc ClusterTask

### DIFF
--- a/config/clustertasks/crane-transfer-pvc.yaml
+++ b/config/clustertasks/crane-transfer-pvc.yaml
@@ -58,6 +58,11 @@ spec:
       description: |
         The name of the networking endpoint to be used for ingress traffic in the destination cluster
       default: ""
+    - name: verify
+      type: string
+      description: |
+        Enable checksum verification (--verify). Valid values are "true" or "false".
+      default: "false"
   steps:
     - name: crane-transfer-pvc
       image: quay.io/konveyor/crane-runner:latest
@@ -79,6 +84,9 @@ spec:
         if [ ! -z "${ENDPOINT_TYPE}" ]; then
           EXTRA_ARGS+=" --endpoint=${ENDPOINT_TYPE}"
         fi
+        if [ "${VERIFY}" == "true" ]; then
+          EXTRA_ARGS+=" --verify"
+        fi
 
         crane transfer-pvc \
           --source-context=$(params.source-context) \
@@ -99,6 +107,8 @@ spec:
           value: $(params.dest-storage-requests)
         - name: ENDPOINT_TYPE
           value: $(params.endpoint-type)
+        - name: VERIFY
+          value: $(params.verify)
   workspaces:
     - name: kubeconfig
       description: |


### PR DESCRIPTION
Needed for https://github.com/konveyor/crane-ui-plugin/issues/99.

The `crane transfer-pvc` CLI command has a boolean `--verify` flag ([source here](https://github.com/konveyor/crane/blob/main/cmd/transfer-pvc/transfer-pvc.go#L183)) that is not exposed in the crane-transfer-pvc ClusterTask. This PR adds a string param `verify` that includes this flag in the command if it is set to the string `"true"`. (because apparently there's [no such thing as a boolean type for a param](https://tekton.dev/docs/pipelines/tasks/#parameter-type)?)

I considered instead adding a param for `extra-flags` which could be set to `"--verify"` or whatever arbitrary CLI flags the user needs to set, but this seemed cleaner.

cc @djzager 